### PR TITLE
Add root env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://ourglass:password@db:5432/ourglassdb


### PR DESCRIPTION
## Summary
- add missing `.env.example` with PostgreSQL DATABASE_URL

## Testing
- `npm test` *(fails: Can't reach database server at `db:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6884758f75b08327b29ff51974b1af2a