### PR TITLE
Implement artwork submission & approval system

### DIFF
--- a/backend/middleware/requireAdmin.js
+++ b/backend/middleware/requireAdmin.js
@@ -1,0 +1,6 @@
+module.exports = function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "pretest": "if [ ! -f .env ]; then cp .env.example .env; fi",
     "db:setup": "./db-setup.sh",
     "test": "npm run db:setup && jest --runInBand",
-    "postinstall": "npm run db:setup"
+    "postinstall": "npm run db:setup",
+    "seed": "node prisma/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma/migrations/20250726141037_artwork_submission/migration.sql
+++ b/backend/prisma/migrations/20250726141037_artwork_submission/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "artworks" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "price_estimate" REAL,
+    "image_url" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sponsorship_phase_start" DATETIME,
+    "ownership_phase_start" DATETIME,
+    CONSTRAINT "artworks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   name           String?
   role           String?
   artworks       Artwork[]
+  galleryArtworks GalleryArtwork[]
   bids           Bid[]
   sponsorships   Sponsorship[]
 }
@@ -74,4 +75,26 @@ model Sponsorship {
   createdAt      DateTime        @default(now())
 
   @@index([artworkId])
+}
+
+enum GalleryStatus {
+  pending
+  approved
+  rejected
+}
+
+model GalleryArtwork {
+  id                     Int      @id @default(autoincrement())
+  user                   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                 String
+  title                  String
+  description            String?
+  priceEstimate          Float?   @map("price_estimate")
+  imageUrl               String?  @map("image_url")
+  status                 GalleryStatus @default(pending)
+  createdAt              DateTime @default(now()) @map("created_at")
+  sponsorshipPhaseStart  DateTime? @map("sponsorship_phase_start")
+  ownershipPhaseStart    DateTime? @map("ownership_phase_start")
+
+  @@map("artworks")
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,22 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+async function main() {
+  // ensure at least one user exists
+  let user = await prisma.user.findFirst();
+  if (!user) {
+    user = await prisma.user.create({ data: { email: 'user@example.com', passwordHash: 'hash' } });
+  }
+  const entries = [
+    { title: 'Sunset', description: 'Sunset description', priceEstimate: 100, imageUrl: 'https://example.com/1.jpg', status: 'approved' },
+    { title: 'Portrait', description: 'Portrait description', priceEstimate: 200, imageUrl: 'https://example.com/2.jpg', status: 'pending' },
+    { title: 'Landscape', description: 'Landscape description', priceEstimate: 150, imageUrl: 'https://example.com/3.jpg', status: 'rejected' },
+    { title: 'Abstract', description: 'Abstract description', priceEstimate: 120, imageUrl: 'https://example.com/4.jpg', status: 'approved' },
+    { title: 'Still Life', description: 'Still Life description', priceEstimate: 80, imageUrl: 'https://example.com/5.jpg', status: 'pending' },
+  ];
+  for (const data of entries) {
+    await prisma.galleryArtwork.create({ data: { ...data, userId: user.id } });
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/backend/routes/artworks.js
+++ b/backend/routes/artworks.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const prisma = require('../prismaClient');
+const requireAuth = require('../middleware/requireAuth');
+const requireAdmin = require('../middleware/requireAdmin');
+
+const router = express.Router();
+
+// Submit new artwork
+router.post('/', requireAuth, async (req, res) => {
+  const { title, description, price_estimate, image_url } = req.body;
+  if (!title) return res.status(400).json({ error: 'Title required' });
+  try {
+    const artwork = await prisma.galleryArtwork.create({
+      data: {
+        title,
+        description,
+        priceEstimate: price_estimate,
+        imageUrl: image_url,
+        userId: req.user.id,
+      },
+    });
+    res.json(artwork);
+  } catch (err) {
+    res.status(400).json({ error: 'Creation failed' });
+  }
+});
+
+// Public gallery - approved only
+router.get('/', async (req, res) => {
+  const artworks = await prisma.galleryArtwork.findMany({
+    where: { status: 'approved' },
+  });
+  res.json(artworks);
+});
+
+// Current user's artworks
+router.get('/mine', requireAuth, async (req, res) => {
+  const artworks = await prisma.galleryArtwork.findMany({
+    where: { userId: req.user.id },
+  });
+  res.json(artworks);
+});
+
+// Pending artworks for admin
+router.get('/pending', requireAuth, requireAdmin, async (req, res) => {
+  const artworks = await prisma.galleryArtwork.findMany({
+    where: { status: 'pending' },
+  });
+  res.json(artworks);
+});
+
+// Admin status update
+router.patch('/:id/status', requireAuth, requireAdmin, async (req, res) => {
+  const { status } = req.body;
+  if (!['approved', 'rejected'].includes(status)) {
+    return res.status(400).json({ error: 'Invalid status' });
+  }
+  try {
+    const artwork = await prisma.galleryArtwork.update({
+      where: { id: parseInt(req.params.id, 10) },
+      data: { status },
+    });
+    res.json(artwork);
+  } catch (err) {
+    res.status(404).json({ error: 'Not found' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -13,7 +13,7 @@ router.post('/register', async (req, res) => {
   }
   try {
     const passwordHash = await bcrypt.hash(password, 10);
-    const user = await prisma.user.create({ data: { email, passwordHash } });
+    const user = await prisma.user.create({ data: { email, passwordHash, role: 'user' } });
     res.json({ id: user.id, email: user.email });
   } catch (err) {
     res.status(400).json({ error: 'Registration failed' });
@@ -30,7 +30,7 @@ router.post('/login', async (req, res) => {
   if (!valid) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
-  const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '7d' });
+  const token = jwt.sign({ id: user.id, email: user.email, role: user.role }, process.env.JWT_SECRET, { expiresIn: '7d' });
   res.cookie('token', token, { httpOnly: true });
   res.json({ id: user.id, email: user.email });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ app.get('/health', (req, res) => {
 });
 
 app.use('/api', require('./routes/auth'));
+app.use('/api/artworks', require('./routes/artworks'));
 
 if (require.main === module) {
   app.listen(PORT, () => {

--- a/backend/tests/artworks.test.js
+++ b/backend/tests/artworks.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest');
+const prisma = require('../prismaClient');
+let app;
+let server;
+let agent;
+let adminAgent;
+
+beforeAll(async () => {
+  app = require('../server');
+  server = app.listen(0);
+  agent = request.agent(server);
+  adminAgent = request.agent(server);
+
+  await agent.post('/api/register').send({ email: 'user1@example.com', password: 'password123' });
+  await agent.post('/api/login').send({ email: 'user1@example.com', password: 'password123' });
+
+  await adminAgent.post('/api/register').send({ email: 'admin@example.com', password: 'password123' });
+  await prisma.user.update({ where: { email: 'admin@example.com' }, data: { role: 'admin' } });
+  await adminAgent.post('/api/login').send({ email: 'admin@example.com', password: 'password123' });
+});
+
+afterAll(async () => {
+  server.close();
+  await prisma.$disconnect();
+});
+
+describe('artwork submission flow', () => {
+  let artworkId;
+
+  it('blocks unauthenticated submission', async () => {
+    const res = await request(app).post('/api/artworks').send({ title: 'NoAuth' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('requires title', async () => {
+    const res = await agent.post('/api/artworks').send({});
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('submits artwork', async () => {
+    const res = await agent.post('/api/artworks').send({ title: 'My Art', description: 'desc' });
+    expect(res.statusCode).toBe(200);
+    artworkId = res.body.id;
+    expect(res.body.status).toBe('pending');
+  });
+
+  it('non-admin cannot approve', async () => {
+    const res = await agent.patch(`/api/artworks/${artworkId}/status`).send({ status: 'approved' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('admin approves artwork', async () => {
+    const res = await adminAgent.patch(`/api/artworks/${artworkId}/status`).send({ status: 'approved' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe('approved');
+  });
+
+  it('gallery shows approved only', async () => {
+    await agent.post('/api/artworks').send({ title: 'Another', description: '' });
+    const res = await request(app).get('/api/artworks');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBe(1); // only the approved one
+  });
+
+  it('user can see their artworks', async () => {
+    const res = await agent.get('/api/artworks/mine');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+});

--- a/frontend/src/app/admin/artworks/page.tsx
+++ b/frontend/src/app/admin/artworks/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function AdminArtworks() {
+  const [items, setItems] = useState<any[]>([]);
+
+  async function load() {
+    const res = await fetch("/api/artworks/pending", { credentials: "include" });
+    if (res.ok) setItems(await res.json());
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function update(id: number, status: string) {
+    await fetch(`/api/artworks/${id}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ status }),
+    });
+    load();
+  }
+
+  return (
+    <ul>
+      {items.map((a) => (
+        <li key={a.id} className="flex gap-2 items-center">
+          <span className="flex-1">{a.title}</span>
+          <button onClick={() => update(a.id, "approved")}>Approve</button>
+          <button onClick={() => update(a.id, "rejected")}>Reject</button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/app/artworks/new/page.tsx
+++ b/frontend/src/app/artworks/new/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function NewArtwork() {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [price, setPrice] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const router = useRouter();
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch("/api/artworks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        title,
+        description,
+        price_estimate: price ? parseFloat(price) : undefined,
+        image_url: imageUrl,
+      }),
+    });
+    if (res.ok) router.push("/dashboard/artworks");
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-4">
+      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
+      <textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" />
+      <input value={price} onChange={(e) => setPrice(e.target.value)} placeholder="Price Estimate" />
+      <input value={imageUrl} onChange={(e) => setImageUrl(e.target.value)} placeholder="Image URL" />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/frontend/src/app/artworks/page.tsx
+++ b/frontend/src/app/artworks/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function Gallery() {
+  const [items, setItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/artworks")
+      .then((res) => res.json())
+      .then(setItems);
+  }, []);
+
+  return (
+    <ul>
+      {items.map((a) => (
+        <li key={a.id}>
+          {a.title} - ${'{'}a.priceEstimate ?? 'N/A'{'}'}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/app/dashboard/artworks/page.tsx
+++ b/frontend/src/app/dashboard/artworks/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function MyArtworks() {
+  const [items, setItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/artworks/mine", { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : []))
+      .then(setItems);
+  }, []);
+
+  return (
+    <ul>
+      {items.map((a) => (
+        <li key={a.id}>
+          {a.title} - {a.status}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add GalleryArtwork model and migration with seed script
- implement authentication role checks and new artwork API routes
- add admin middleware and update auth token payload
- create Next.js pages for gallery, submissions, dashboards
- add integration tests for artwork flows

## Testing
- `DATABASE_URL=file:./dev.db DATABASE_PROVIDER=sqlite npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884e0b75b1c8327833cdb5c84676a15